### PR TITLE
Adding python package for snappi and ixnetwork restpy

### DIFF
--- a/dockerfiles/Dockerfile.client
+++ b/dockerfiles/Dockerfile.client
@@ -62,7 +62,7 @@ RUN git clone https://github.com/opencomputeproject/SAI.git \
 RUN pip3 install pytest pytest_dependency pytest-html pdbpp macaddress click==8.0
 
 # Install snappi
-RUN python3 -m pip install --upgrade "snappi[ixnetwork,convergence]==0.9.1"
+RUN pip3 install snappi==0.9.8 snappi_ixnetwork==0.9.1
 
 # Install PTF dependencies
 RUN pip3 install scapy dpkt

--- a/dockerfiles/Dockerfile.client
+++ b/dockerfiles/Dockerfile.client
@@ -61,6 +61,12 @@ RUN git clone https://github.com/opencomputeproject/SAI.git \
 # Install SAI-C dependencies
 RUN pip3 install pytest pytest_dependency pytest-html pdbpp macaddress click==8.0
 
+# Install snappi
+RUN python3 -m pip install --upgrade "snappi[ixnetwork,convergence]==0.9.1"
+
+#Install Ixnetwork Restpy
+RUN pip3 install ixnetwork-restpy
+
 # Install PTF dependencies
 RUN pip3 install scapy dpkt
 

--- a/dockerfiles/Dockerfile.client
+++ b/dockerfiles/Dockerfile.client
@@ -64,9 +64,6 @@ RUN pip3 install pytest pytest_dependency pytest-html pdbpp macaddress click==8.
 # Install snappi
 RUN python3 -m pip install --upgrade "snappi[ixnetwork,convergence]==0.9.1"
 
-#Install Ixnetwork Restpy
-RUN pip3 install ixnetwork-restpy
-
 # Install PTF dependencies
 RUN pip3 install scapy dpkt
 


### PR DESCRIPTION
Adding python package install for snappi and ixnetwork restpy in the Dockerfile.client for executing vlan snappi test case