### PR TITLE
Logic for snappi port location

### DIFF
--- a/common/sai_dataplane/snappi/sai_snappi_dataplane.py
+++ b/common/sai_dataplane/snappi/sai_snappi_dataplane.py
@@ -36,8 +36,12 @@ class SaiSnappiDataPlane(SaiDataPlane):
         # IxNetwork:    port.location = "<chassisip>;card;port"
         # TRex:         port.location = "localhost:5555"
         for pid, port in enumerate(self.config['port_groups']):
-            location = port.get('location', f"localhost:{BASE_TENGINE_PORT+pid}")
-            self.configuration.ports.port(name=port["name"], location=location)
+            if self.mode == 'ixnet':
+                location = port['location']
+                self.configuration.ports.port(name=port["name"], location=location)
+            else:
+                location = port.get('location', f"localhost:{BASE_TENGINE_PORT+pid}")
+                self.configuration.ports.port(name=port["name"], location=location)
 
         cap = self.configuration.captures.capture(name="c1")[-1]
         cap.port_names = [p.name for p in self.configuration.ports]


### PR DESCRIPTION
If the mode is ixnet then the logic for port location has been modified according to the sainpu_sonic.json file